### PR TITLE
Fixes on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,28 +107,31 @@ The reason all relative dependency paths are relative to the *base directory* in
 usage: scantree [--file|--dir]=path [opt ...]
 
 Options:
---help                    show this help
+--help                      show this help
 
---file=file               scan a single file
---dir=directory           scan all files in a directory
---exclude=pattern         exclude any included paths that match pattern (JS regex)
+--file=file                 scan a single file
+--dir=directory             scan all files in a directory
+--exclude=pattern           exclude any included paths that match pattern (JS regex)
 
---base-dir=directory      search relative dependency paths starting from this location
---output=[simple|json]    output simple linear list of null-separated values, or JSON
-                          (default: json)
+--base-dir=directory        search relative dependency paths starting from this location
+--output=[simple|json]      output simple linear list of null-separated values, or JSON
+                            (default: json)
 
--R, --recursive           directory scan is recursive
-                          (default: off)
--F, --full-paths          include full paths in all dependencies; otherwise strip
-                          BASE-DIR from paths
-                          (default: off)
--G, --groups              group parallel dependencies -- those which don't depend on
-                          each other and can thus run in arbitrary order
-                          (JSON only, default: on)
--N, --no-groups           don't group parallel dependencies
-                          (JSON only)
--M, --ignore-missing      ignore missing dependency files
--I, --ignore-invalid      ignore JS parsing issues
+-R, --recursive             directory scan is recursive
+                            (default: off)
+-F, --full-paths            include full paths in all dependencies; otherwise strip
+                            BASE-DIR from paths
+                            (default: off)
+-S, --force-slash-separator force output to use slash as file path separator; otherwise \n",
+                            it will keep the default platform separator\n",
+                            (default: off)\n",
+-G, --groups                group parallel dependencies -- those which don't depend on
+                            each other and can thus run in arbitrary order
+                            (JSON only, default: on)
+-N, --no-groups             don't group parallel dependencies
+                            (JSON only)
+-M, --ignore-missing        ignore missing dependency files
+-I, --ignore-invalid        ignore JS parsing issues
 ```
 
 You specify file(s) to scan by using one or more `--file` and/or `--dir` flags.
@@ -138,6 +141,8 @@ You specify file(s) to scan by using one or more `--file` and/or `--dir` flags.
 If you use `--dir`, that directory's contents will be examined (non-recursively), and all found JS files will be scanned. Use `--recursive (-R)` to recursively examine sub-directories. To exclude any files/paths from this processing, use one or more `--exclude` flags, specifying a JS-style regular expression to match for exclusion (note: to avoid shell escaping issues, surround your regex in ' ' quotes).
 
 All dependency annotations with relative filepaths will default to resolving against the current directory where the tool is being invoked. If you want to set a different base directory, use `--base-dir`. By default, all paths that are relative to the base directory (default or specified) will be output as relative (base directory trimmed). To output full filepaths instead, use `--full-paths (-F)`.
+
+The separator used by scantree in the paths is based on the platform separator. Typically on windows the separator will be backslash (\). If you want to force the output to use an slash instead (/), you can use `--force-slash-separator (-S)`. That option is a noop if the slash is already the separator (i.e. on linux).
 
 By default, the [output will be valid JSON](#json-output): an array of the files in the order they need to be executed to satisfy the dependencies. To suppress JSON and [output a null-separated list](#simple-output) of file paths (like `find .. --print0` suitable for `xargs -0`-style processing), use `--output=simple`.
 
@@ -167,6 +172,7 @@ The `options` correspond similarly to the [CLI parameters](#cli) described above
 * `output` (`string`: `"simple"`, `"json"`): specifies the output format
 * `recursive` (`boolean`, default: `false`): make directory scans recursive
 * `full_paths` (`boolean`, default: `false`): include full paths for dependencies
+* `force_slash_separator` (`boolean`, default: `false`): force output to use slash separator
 * `groups` (`boolean`, default: `true`): group "parallel" dependencies in JSON output
 * `ignore` (`object`, `boolean`): if `true`/`false`, will set all sub-properties accordingly; otherwise, should be an object with one or more of these:
   - `ignore.missing` (`boolean`): ignore files or directories not found

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If you use `--dir`, that directory's contents will be examined (non-recursively)
 
 All dependency annotations with relative filepaths will default to resolving against the current directory where the tool is being invoked. If you want to set a different base directory, use `--base-dir`. By default, all paths that are relative to the base directory (default or specified) will be output as relative (base directory trimmed). To output full filepaths instead, use `--full-paths (-F)`.
 
-The separator used by scantree in the paths is based on the platform separator. Typically on windows the separator will be backslash (\). If you want to force the output to use an slash instead (/), you can use `--force-slash-separator (-S)`. That option is a noop if the slash is already the separator (i.e. on linux).
+The separator used by scantree in the paths is based on the platform separator. Typically on windows the separator will be backslash (\\). If you want to force the output to use an slash instead (/), you can use `--force-slash-separator (-S)`. That option is a noop if the slash is already the separator (i.e. on linux).
 
 By default, the [output will be valid JSON](#json-output): an array of the files in the order they need to be executed to satisfy the dependencies. To suppress JSON and [output a null-separated list](#simple-output) of file paths (like `find .. --print0` suitable for `xargs -0`-style processing), use `--output=simple`.
 

--- a/bin/scantree
+++ b/bin/scantree
@@ -1,20 +1,21 @@
 #!/usr/bin/env node
 
 "use strict";
-
 var path = require("path"),
 	args = require("minimist")(process.argv,{
-		boolean: [ "recursive", "full-paths", "groups", "ignore-missing", "ignore-invalid" ],
+		boolean: [ "recursive", "full-paths", "force-slash-separator", "groups", "ignore-missing", "ignore-invalid" ],
 		string: [ "file", "dir", "base-dir", "output", "exclude" ],
 		default: {
 			"recursive": false,
 			"full-paths": false,
+			"force-slash-separator": false,
 			"groups": true,
 			"exclude": []
 		},
 		alias: {
 			"recursive": "R",
 			"full-paths": "F",
+			"force-slash-separator": "S",
 			"groups": "G",
 			"no-groups": "N",
 			"ignore-missing": "M",
@@ -23,7 +24,6 @@ var path = require("path"),
 	}),
 	scantree = require(path.join(__dirname,"..","lib","index.js"))
 ;
-
 main();
 
 // ***********************************
@@ -36,28 +36,31 @@ function printHelp() {
 		"usage: scantree [--file|--dir]=path [opt ...]\n",
 		"\n",
 		"Options:\n",
-		"--help                    show this help\n",
+		"--help                      show this help\n",
 		"\n",
-		"--file=file               scan a single file\n",
-		"--dir=directory           scan all files in a directory\n",
-		"--exclude=pattern         exclude any included paths that match pattern (JS regex)\n",
+		"--file=file                 scan a single file\n",
+		"--dir=directory             scan all files in a directory\n",
+		"--exclude=pattern           exclude any included paths that match pattern (JS regex)\n",
 		"\n",
-		"--base-dir=directory      search relative dependency paths starting from this location\n",
-		"--output=[simple|json]    output simple linear list of null-separated values, or JSON\n",
-		"                          (default: json)\n",
+		"--base-dir=directory        search relative dependency paths starting from this location\n",
+		"--output=[simple|json]      output simple linear list of null-separated values, or JSON\n",
+		"                            (default: json)\n",
 		"\n",
-		"-R, --recursive           directory scan is recursive\n",
-		"                          (default: off)\n",
-		"-F, --full-paths          include full paths in all dependencies; otherwise strip\n",
-		"                          BASE-DIR from paths\n",
-		"                          (default: off)\n",
-		"-G, --groups              group parallel dependencies -- those which don't depend on\n",
-		"                          each other and can thus run in arbitrary order\n",
-		"                          (JSON only, default: on)\n",
-		"-N, --no-groups           don't group parallel dependencies\n",
-		"                          (JSON only)\n",
-		"-M, --ignore-missing      ignore missing dependency files\n",
-		"-I, --ignore-invalid      ignore JS parsing issues\n"
+		"-R, --recursive             directory scan is recursive\n",
+		"                            (default: off)\n",
+		"-F, --full-paths            include full paths in all dependencies; otherwise strip\n",
+		"                            BASE-DIR from paths\n",
+		"                            (default: off)\n",
+		"-S, --force-slash-separator force output to use slash as file path separator; otherwise \n",
+		"                            it will keep the default platform separator\n",
+		"                            (default: off)\n",
+		"-G, --groups                group parallel dependencies -- those which don't depend on\n",
+		"                            each other and can thus run in arbitrary order\n",
+		"                            (JSON only, default: on)\n",
+		"-N, --no-groups             don't group parallel dependencies\n",
+		"                            (JSON only)\n",
+		"-M, --ignore-missing        ignore missing dependency files\n",
+		"-I, --ignore-invalid        ignore JS parsing issues\n"
 	);
 }
 
@@ -141,6 +144,12 @@ function validateParams() {
 		QUIT("'--full-paths (-F)' must have no value");
 	}
 	else if (
+		"force-slash-separator" in args &&
+		typeof args["force-slash-separator"] != "boolean"
+	) {
+		QUIT("'--force-slash-separator (-S)' must have no value");
+	}
+	else if (
 		args.output &&
 		!(
 			args.output === "simple" ||
@@ -207,6 +216,7 @@ function main() {
 			output: args.output,
 			recursive: args.recursive,
 			full_paths: args["full-paths"],
+			force_slash_separator: args["force-slash-separator"],
 			groups: args.groups,
 
 			ignore: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,8 @@ var fs = require("fs"),
 	curdep,
 
 	OPTS,
-
+	// escaped specially for win platform, since "\\" would make the reg exp fail
+	escaped_path_sep = path.sep.replace(/\\/g, "\\\\"),
 	DIR_BASE,
 	DIR_HOME = (
 		os.homedir ?
@@ -79,7 +80,7 @@ function fixPath(pathStr) {
 		if (/^~/.test(pathStr)) {
 			pathStr = resolveHomeDir(pathStr);
 		}
-		else if (!(new RegExp("^[" + path.sep + "]")).test(pathStr)) {
+		else if (!(new RegExp("^[" + escaped_path_sep + "]")).test(pathStr)) {
 			pathStr = path.join(DIR_BASE,pathStr);
 		}
 	}
@@ -161,6 +162,12 @@ function validateOptions() {
 		typeof OPTS.full_paths != "boolean"
 	) {
 		throw new Error("'full_paths' option must be true/false");
+	}
+	else if (
+		OPTS.force_slash_separator != null &&
+		typeof OPTS.force_slash_separator != "boolean"
+	) {
+		throw new Error("'force_slash_separator' option must be true/false");
 	}
 	else if (
 		OPTS.output != null &&
@@ -250,7 +257,7 @@ function processOptions() {
 	}
 
 	// normalize DIR_BASE
-	if (!(new RegExp("[" + path.sep + "]$")).test(DIR_BASE)) {
+	if (!(new RegExp("[" + escaped_path_sep + "]$")).test(DIR_BASE)) {
 		DIR_BASE += path.sep;
 	}
 }
@@ -474,6 +481,13 @@ function walkTree(tree) {
 			node.src.indexOf(DIR_BASE) === 0
 		) {
 			node.src = node.src.substr(DIR_BASE.length);
+		}
+		
+		// force slash separator, replace it
+		if (OPTS.force_slash_separator &&
+			!isURL(node.src)
+		) {
+			node.src = node.src.replace(new RegExp(escaped_path_sep,"g"), "/");
 		}
 	});
 

--- a/tests.js
+++ b/tests.js
@@ -4,6 +4,7 @@ var childproc = require("child_process"),
 	scantree = require("./"),
 
 	DIR_CWD = process.cwd(),
+	path = require("path"),
 	test_idx = 0,
 
 	cli_tests,
@@ -12,122 +13,122 @@ var childproc = require("child_process"),
 
 cli_tests = [
 	{
-		command: "bin/scantree --file=test/a.js --base-dir=test/",
+		command: "node bin/scantree --force-slash-separator --file=test/a.js --base-dir=test/",
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js"]'
 	},
 	{
-		command: "bin/scantree --file=test/a.js --file=test/baz/bam/h.js --base-dir=test/",
+		command: "node bin/scantree --force-slash-separator --file=test/a.js --file=test/baz/bam/h.js --base-dir=test/",
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js",["baz/bam/g.js","i.js"],"baz/bam/h.js"]'
 	},
 	{
-		command: "bin/scantree --dir=test/ --base-dir=test/",
+		command: "node bin/scantree --force-slash-separator --dir=test/ --base-dir=test/",
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js","i.js"]'
 	},
 	{
-		command: "bin/scantree --dir=test/ --dir=test/foo --dir=test/foo/bar --dir=test/baz --dir=test/baz/bam --base-dir=test/",
+		command: "node bin/scantree --force-slash-separator --dir=test/ --dir=test/foo --dir=test/foo/bar --dir=test/baz --dir=test/baz/bam --base-dir=test/",
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js",["baz/bam/g.js","i.js"],"baz/bam/h.js"]'
 	},
 	{
-		command: "bin/scantree --dir=test/ --base-dir=test/ --recursive",
+		command: "node bin/scantree --force-slash-separator --dir=test/ --base-dir=test/ --recursive",
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js",["baz/bam/g.js","i.js"],"baz/bam/h.js"]'
 	},
 	{
-		command: "bin/scantree --dir=test/ --base-dir=test/ --recursive --exclude='d\\.js' --exclude='[abc]\\.js'",
+		command: "node bin/scantree --force-slash-separator --dir=test/ --base-dir=test/ --recursive --exclude=\"d\\.js\" --exclude=\"[abc]\\.js\"",
 		assert: '[["baz/bam/g.js","i.js"],["baz/bam/h.js","baz/f.js","e.js"]]'
 	},
 	{
-		command: "bin/scantree --dir=test/ --base-dir=test/ --recursive --no-groups",
+		command: "node bin/scantree --force-slash-separator --dir=test/ --base-dir=test/ --recursive --no-groups",
 		assert: '["http://some.url/j.js","baz/f.js","e.js","foo/c.js","foo/bar/d.js","foo/b.js","a.js","baz/bam/g.js","i.js","baz/bam/h.js"]'
 	},
 	{
-		command: "bin/scantree --dir=test/ --base-dir=test/ --recursive --full-paths",
+		command: "node bin/scantree --force-slash-separator --dir=test/ --base-dir=test/ --recursive --full-paths",
 		assert: '[["http://some.url/j.js","/tmp/test/baz/f.js","/tmp/test/e.js"],"/tmp/test/foo/c.js",["/tmp/test/foo/bar/d.js","/tmp/test/foo/b.js"],"/tmp/test/a.js",["/tmp/test/baz/bam/g.js","/tmp/test/i.js"],"/tmp/test/baz/bam/h.js"]'
 			.replace(/"\/tmp/g,function(){
-				return '"' + DIR_CWD;
+				return '"' + DIR_CWD.replace(/\\/g,"/");
 			})
 	},
 	{
-		command: "bin/scantree --dir=test/ --base-dir=test/ --recursive --output=simple",
+		command: "node bin/scantree --force-slash-separator --dir=test/ --base-dir=test/ --recursive --output=simple",
 		assert: ['http://some.url/j.js','baz/f.js','e.js','foo/c.js','foo/bar/d.js','foo/b.js','a.js','baz/bam/g.js','i.js','baz/bam/h.js']
 			.join("\0") + "\0"
 	},
 	{
-		command: "bin/scantree --file='http://some.url/j.js' --file='http://some.url/k.js' --dir=test/ --base-dir=test/ --recursive",
+		command: "node bin/scantree --force-slash-separator --file=\"http://some.url/j.js\" --file=\"http://some.url/k.js\" --dir=test/ --base-dir=test/ --recursive",
 		assert: '[["http://some.url/j.js","e.js","baz/f.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js",["baz/bam/g.js","i.js"],["http://some.url/k.js","baz/bam/h.js"]]'
 	},
 	{
-		command: "bin/scantree --file=README.md",
-		assert: 'scantree: Invalid: /tmp/README.md\nSyntaxError: Unexpected character \'#\' (1:0)'
-			.replace(/\/tmp/g,function(){
-				return DIR_CWD;
+		command: "node bin/scantree --file=README.md",
+		assert: 'scantree: Invalid: tmp/README.md\nSyntaxError: Unexpected character \'#\' (1:0)'
+			.replace(/tmp\//g,function(){
+				return DIR_CWD + path.sep;
 			})
 	},
 	{
-		command: "bin/scantree --file=GONE.txt",
-		assert: 'scantree: Not found: /tmp/GONE.txt'
-			.replace(/\/tmp/g,function(){
-				return DIR_CWD;
+		command: "node bin/scantree --file=GONE.txt",
+		assert: 'scantree: Not found: tmp/GONE.txt'
+			.replace(/tmp\//g,function(){
+				return DIR_CWD + path.sep;
 			})
 	}
 ];
 
 lib_tests = [
 	{
-		opts: { files: "test/a.js", base_dir: "test/" },
+		opts: { files: "test/a.js", base_dir: "test/", force_slash_separator: true },
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js"]'
 	},
 	{
-		opts: { files: ["test/a.js", "test/baz/bam/h.js"], base_dir: "test/" },
+		opts: { files: ["test/a.js", "test/baz/bam/h.js"], base_dir: "test/", force_slash_separator: true },
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js",["baz/bam/g.js","i.js"],"baz/bam/h.js"]'
 	},
 	{
-		opts: { dirs: "test/", base_dir: "test/" },
+		opts: { dirs: "test/", base_dir: "test/", force_slash_separator: true },
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js","i.js"]'
 	},
 	{
-		opts: { dirs: ["test/", "test/foo", "test/foo/bar", "test/baz", "test/baz/bam"], base_dir: "test/" },
+		opts: { dirs: ["test/", "test/foo", "test/foo/bar", "test/baz", "test/baz/bam"], base_dir: "test/", force_slash_separator: true },
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js",["baz/bam/g.js","i.js"],"baz/bam/h.js"]'
 	},
 	{
-		opts: { dirs: "test/", base_dir: "test/", recursive: true },
+		opts: { dirs: "test/", base_dir: "test/", recursive: true, force_slash_separator: true },
 		assert: '[["http://some.url/j.js","baz/f.js","e.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js",["baz/bam/g.js","i.js"],"baz/bam/h.js"]'
 	},
 	{
-		opts: { dirs: "test/", base_dir: "test/", recursive: true, excludes: ["d\\.js", "[abc]\\.js"] },
+		opts: { dirs: "test/", base_dir: "test/", recursive: true, excludes: ["d\\.js", "[abc]\\.js"], force_slash_separator: true },
 		assert: '[["baz/bam/g.js","i.js"],["baz/bam/h.js","baz/f.js","e.js"]]'
 	},
 	{
-		opts: { dirs: "test/", base_dir: "test/", recursive: true, groups: false },
+		opts: { dirs: "test/", base_dir: "test/", recursive: true, groups: false, force_slash_separator: true },
 		assert: '["http://some.url/j.js","baz/f.js","e.js","foo/c.js","foo/bar/d.js","foo/b.js","a.js","baz/bam/g.js","i.js","baz/bam/h.js"]'
 	},
 	{
-		opts: { dirs: "test/", base_dir: "test/", recursive: true, full_paths: true },
+		opts: { dirs: "test/", base_dir: "test/", recursive: true, full_paths: true, force_slash_separator: true },
 		assert: '[["http://some.url/j.js","/tmp/test/baz/f.js","/tmp/test/e.js"],"/tmp/test/foo/c.js",["/tmp/test/foo/bar/d.js","/tmp/test/foo/b.js"],"/tmp/test/a.js",["/tmp/test/baz/bam/g.js","/tmp/test/i.js"],"/tmp/test/baz/bam/h.js"]'
 			.replace(/"\/tmp/g,function(){
-				return '"' + DIR_CWD;
+				return '"' + DIR_CWD.replace(/\\/g,"/");
 			})
 	},
 	{
-		opts: { dirs: "test/", base_dir: "test/", recursive: true, output: "simple" },
+		opts: { dirs: "test/", base_dir: "test/", recursive: true, output: "simple", force_slash_separator: true },
 		assert: ['http://some.url/j.js','baz/f.js','e.js','foo/c.js','foo/bar/d.js','foo/b.js','a.js','baz/bam/g.js','i.js','baz/bam/h.js']
 			.join("\0") + "\0"
 	},
 	{
-		opts: { files: ['http://some.url/j.js','http://some.url/k.js'], dirs: "test/", base_dir: "test/", recursive: true },
+		opts: { files: ['http://some.url/j.js','http://some.url/k.js'], dirs: "test/", base_dir: "test/", recursive: true, force_slash_separator: true },
 		assert: '[["http://some.url/j.js","e.js","baz/f.js"],"foo/c.js",["foo/bar/d.js","foo/b.js"],"a.js",["baz/bam/g.js","i.js"],["http://some.url/k.js","baz/bam/h.js"]]'
 	},
 	{
 		opts: { files: "README.md" },
-		assert: 'Invalid: /tmp/README.md\nSyntaxError: Unexpected character \'#\' (1:0)'
-			.replace(/\/tmp/g,function(){
-				return DIR_CWD;
+		assert: 'Invalid: tmp/README.md\nSyntaxError: Unexpected character \'#\' (1:0)'
+			.replace(/tmp\//g,function(){
+				return DIR_CWD + path.sep;;
 			})
 	},
 	{
 		opts: { files: "GONE.txt" },
-		assert: 'Not found: /tmp/GONE.txt'
-			.replace(/\/tmp/g,function(){
-				return DIR_CWD;
+		assert: 'Not found: tmp/GONE.txt'
+			.replace(/tmp\//g,function(){
+				return DIR_CWD + path.sep;;
 			})
 	}
 ];


### PR DESCRIPTION
I was trying to use this package on windows, but it is not working because windows native separator is backslash, and then all RegExp created using path.sep were failing all over.

In this branch I added code to escape the backslash separator.

Then, when running unit tests, tests were also failing because of:

1) On windows if the package is not installed globally, the tests were failing to find ./bin/scantree. I changed the test execution to do "node ./bin/scantree" instead.
Also, given these changes, the quoting of parameters on the tests had to be changed from "... --s='blah' .. " to "... --s=\"blah\" ..".

2) All tests were expecting the output to use the native separator, so tests would fail on windows. I realized that even on windows some users on windows may want to get the output using the slash separator in paths. So I added a new option to do exactly that, and took advantage of it to keep the tests consistent and passing.

Readme was updated too.

Thanks for creating this package.
